### PR TITLE
Fix not detecting mpv output.

### DIFF
--- a/adl
+++ b/adl
@@ -235,7 +235,7 @@ watch() { #{{{
     "vlc")
       watched=$(echo "$out" | grep 'Command Line Interface initialized' | wc -l) ;;
     "mpv")
-      watched=$(echo "$out" | grep 'Playing: ' | wc -l) ;;
+      watched=$(echo "$out" | grep 'fps' | wc -l) ;;
     *)
       watched=1 ;;
   esac


### PR DESCRIPTION
Mpv changed its output so when you use it now the script thinks the video didnt start when in reality it did