### PR TITLE
ctrlc and updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ chmod +x "$HOME/bin/adl"
 ```
 If you are using Arch Linux you can install from the [Arch Linux User Repository (AUR)](https://aur.archlinux.org/packages/adl-git/) thanks to [@Baitinq](https://github.com/Baitinq).
 
+### Updating
+
+`adl` also has a function for updating itself from source. To use it run `adl -u` or `adl --update` and follow the prompts.
+
 ### Issues
 
 If the show doesn't start for you, the script will inform you of this. If you are positive that the episode number has aired, then most likely the provider you are using is NOT yet up-to-date. If you want to try every provider to see where your show is hosted you can try this bash code to cycle through all of them.

--- a/adl
+++ b/adl
@@ -46,7 +46,7 @@ watching_prompt() { echo -e "\nNow watching \033[0;34m$1\033[0m, $2 \033[0;34m$3
 color_print()     { echo -e "\033[0;36m$@ \033[0m" ;} #for normal output
 color_prompt()    { printf "\033[0;34m$@\033[0m" ;} #for user input
 print_help()      { sed -n "s/##\ //p" "$0" ;} # more compact than { grep "^##" "$0" | sed -e "s/^...//" ;}
-print_options()   { print_help | tail -10 ;}
+print_options()   { print_help | tail -11 ;}
 print_version()   { print_help | head -2  ;}
 print_noconfirm() { color_print "\nDefault option chosen due to option '-y'.\n" ;}
 get_list()        { #{{{

--- a/adl
+++ b/adl
@@ -12,6 +12,7 @@
 ##   -r, --retrieve    Run trackma retrieve to update local list
 ##   -f, --frece       Optionally adl can use frece to show most watched anime at the top of the list in fzf;
 ##   -a, --account     By default trackma will use account 1. Use '-a "2"' for example to change trackma account;
+##   -u, --update      Update this script from github master;
 ##   -h, --help        Display help and exit;
 ##   -v, --version     Display version and exit.
 
@@ -345,6 +346,22 @@ watch_another() { #{{{
   done
 } #}}}
 
+updater() { #{{{
+  DIR=$(cd "$(dirname "$0")" ; pwd)
+  FILE=$(basename "$0")
+  MESSAGE="WARNING: $0 will now overwrite itself at the path: $DIR/$FILE. Proceed? [y/N]: "
+  printf "\033[0;31m$MESSAGE\033[0m" #red warning
+  # integration with -y option crossed my mind but it is unwise
+  read -r updater_ans
+  case $updater_ans in
+    "y"|"Y")
+      wget -q --show-progress "https://raw.githubusercontent.com/RaitaroH/adl/master/adl" -O "$DIR/$FILE"
+      color_print "✓ Update is complete." ;;
+    ""|"n"|"N")
+      color_print "Update aborted." ;;
+  esac
+} #}}}
+
 arguments() { #{{{
   # check if option is interpreted as argument for previous option; match getopt error format
   # \ in printf because $2 was expanded into an argument for printf
@@ -353,7 +370,7 @@ arguments() { #{{{
   fi
 } #}}}
 
-params="$(getopt -o vhp:s:n:a:yrf -l version,help,player:,show:,number:,account:,no-confirm,retrieve,frece --name "$0" -- "$@")"
+params="$(getopt -o vhup:s:n:a:yrf -l version,help,update,player:,show:,number:,account:,no-confirm,retrieve,frece --name "$0" -- "$@")"
 # Check error for getopt
 if [ "$?" -ne 0 ]; then print_options; exit 1; fi
 eval set -- "$params"
@@ -363,6 +380,7 @@ while true; do
   case "$opt" in
     -v|--version) print_version ;  exit 0 ;;
     -h|--help)    print_help    ;  exit 0 ;;
+    -u|--update)  updater       ;  exit 0 ;;
     -p|--player)  arguments "$opt" "$2" player ;;
     -s|--show)    arguments "$opt" "$2" show_title ;;
     -n|--number)  arguments "$opt" "$2" show_episode ;;

--- a/adl
+++ b/adl
@@ -368,7 +368,7 @@ updater() { #{{{
           color_print "Not an actual option. Exiting..."
           exit 1 ;;
       esac
-      color_print "✓ Update from $source is complete." ;;
+      color_print "\n✓ Update from $source is complete." ;;
     ""|"n"|"N")
       color_print "Update aborted." ;;
     *)

--- a/adl
+++ b/adl
@@ -22,6 +22,7 @@ yes=""
 player="mpv"
 account="1"
 retrieve=""
+ctrlc=0
 check_player() { #{{{
   # Exit if "$player" is not installed
   if ! [ -x "$(command -v $player)" ]; then
@@ -39,6 +40,7 @@ check_frece() { #{{{
   fi
   clear
 } #}}}
+trap_ctrlc()      { ctrlc=1 ;}
 watching_prompt() { echo -e "\nNow watching \033[0;34m$1\033[0m, $2 \033[0;34m$3 \033[0m" ;}
 color_print()     { echo -e "\033[0;36m$@ \033[0m" ;} #for normal output
 color_prompt()    { printf "\033[0;34m$@\033[0m" ;} #for user input
@@ -134,6 +136,9 @@ select_function() { #{{{
 } #}}}
 
 animedl() { #{{{
+  # initialise trap to call trap_ctrlc function when signal 2 (SIGINT) is received
+  trap "trap_ctrlc" 2
+
   [[ -z "$yes" ]] && choice="-c 0" || choice="-c 1" #0 is as if is not even there
   if [[ "$4" != "" ]]; then
     { out=$(anime dl --play "$1" "$2" --episodes "$3":"$4" "$choice" | tee >(cat - >&5)); } 5>&1
@@ -248,6 +253,7 @@ watch() { #{{{
     *)
       watched=1 ;;
   esac
+  [[ $ctrlc   == 1 ]] && watched=$(($watched - 1)) # if Ctrl-C was caught one extra episode was counted
   [[ $watched == 0 ]] && color_print "\n$player didn't start, the anime wasn't found, or the episode wasn't found..." && return 0
 
   if [[ -z "$2" ]]; then #only ask if anime is in list
@@ -329,6 +335,7 @@ watch_another() { #{{{
     echo
     case $ans_another in
       ""|"y"|"Y")
+        ctrlc=0 #making sure this counter is reset
         [[ -z "$sent" ]] || color_print "\nRetrieving updated anime list...\n" && get_list
         select_function ;;
       "n"|"N")

--- a/adl
+++ b/adl
@@ -355,10 +355,25 @@ updater() { #{{{
   read -r updater_ans
   case $updater_ans in
     "y"|"Y")
-      wget -q --show-progress "https://raw.githubusercontent.com/RaitaroH/adl/master/adl" -O "$DIR/$FILE"
-      color_print "✓ Update is complete." ;;
+      color_prompt "\nadl can be updated from master or develop. Which one do you choose? [M/d]: "
+      read -r source_ans
+      case $source_ans in
+        ""|"M"|"m")
+          source="master"
+          wget -q --show-progress "https://raw.githubusercontent.com/RaitaroH/adl/master/adl" -O "$DIR/$FILE" ;;
+        "d"|"D")
+          source="develop"
+          wget -q --show-progress "https://raw.githubusercontent.com/RaitaroH/adl/develop/adl" -O "$DIR/$FILE" ;;
+        *)
+          color_print "Not an actual option. Exiting..."
+          exit 1 ;;
+      esac
+      color_print "✓ Update from $source is complete." ;;
     ""|"n"|"N")
       color_print "Update aborted." ;;
+    *)
+      color_print "Not an actual option. Exiting..."
+      exit 1 ;;
   esac
 } #}}}
 

--- a/adl
+++ b/adl
@@ -254,7 +254,7 @@ watch() { #{{{
       watched=1 ;;
   esac
   [[ $ctrlc   == 1 ]] && watched=$(($watched - 1)) # if Ctrl-C was caught one extra episode was counted
-  [[ $watched == 0 ]] && color_print "\n$player didn't start, the anime wasn't found, or the episode wasn't found..." && return 0
+  [[ $watched == 0 && $ctrlc == 0 ]] && color_print "\n$player didn't start, the anime wasn't found, or the episode wasn't found..." && return 0
 
   if [[ -z "$2" ]]; then #only ask if anime is in list
     color_prompt "\n\nIncrease nr in anime list? Yes, no, or custom number [Y/n/c]: "


### PR DESCRIPTION
A PR to merge the changes on develop:
- a function that tells when 'Ctrl-C' is pressed > `adl` can now more accurately count the number of episodes watched
- a function that let's `adl` update itself
  - [x] implement actual function
  - [x] implement `-u / --update` argument for it
  - [x] allow choosing what source: master (stable), or develop (unstable)
  - [x] update README.md accordingly

@Baitinq I will merge this tomorrow.